### PR TITLE
(fix): use http 1.1 in curl connection

### DIFF
--- a/scripts/idesetup
+++ b/scripts/idesetup
@@ -82,7 +82,7 @@ download_and_extract() {
 
     if [ "$do_download" = "true" ]; then
         print_info "Downloading $name..."
-        curl -L -o $dest $url
+        curl -L -o $dest $url  --http1.1
         print_success "$name has been downloaded."
         echo ""
     fi


### PR DESCRIPTION
Fixed `curl: (92) HTTP/2 stream 0 was not closed cleanly: PROTOCOL_ERROR (err 1)`